### PR TITLE
Nav bar homepage에 적용

### DIFF
--- a/src/components/NavBar.module.scss
+++ b/src/components/NavBar.module.scss
@@ -3,7 +3,6 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    width: 100%;
     padding: 25px 70px;
     background-color: white;
     color: black;

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -1,5 +1,7 @@
+import NavBar from "../../components/NavBar";
+
 export function HomePage() {
     return (
-        <div> 홈 </div>
+        <NavBar />
     )
 }


### PR DESCRIPTION
# 요약
- NavBar 컴포넌트를 HomePage 컴포넌트에 적용했습니다.

# 변경사항
- NavBar 컴포넌트의 너비가 width:100% 때문에 뷰포트를 넘어서까지 출력되어서 수정했습니다(근데 왜 뷰포트를 넘는 건가요?? 잘 모름)